### PR TITLE
CANS-253. Caregiver Domain collects Caregiver Name and displays it in header

### DIFF
--- a/app/javascript/Application/components/Assessment/Assessment.js
+++ b/app/javascript/Application/components/Assessment/Assessment.js
@@ -75,6 +75,19 @@ class Assessment extends Component {
     this.props.onAssessmentUpdate(assessment);
   };
 
+  updateCaregiverName = (caregiverIndex, caregiverName) => {
+    const assessment = cloneDeep(this.props.assessment);
+    const domains = assessment.state.domains;
+    for (let i = 0; i < domains.length; i++) {
+      const domain = domains[i];
+      if (domain.caregiver_index === caregiverIndex) {
+        domain.caregiver_name = caregiverName;
+        break;
+      }
+    }
+    this.props.onAssessmentUpdate(assessment);
+  };
+
   render() {
     const i18n = this.props.i18n;
     const assessmentDto = this.props.assessment;
@@ -97,6 +110,7 @@ class Assessment extends Component {
           onConfidentialityUpdate={this.handleUpdateItemConfidentiality}
           onAddCaregiverDomain={this.addCaregiverDomainAfter}
           onRemoveCaregiverDomain={this.removeCaregiverDomain}
+          onCaregiverNameUpdate={this.updateCaregiverName}
         />
       );
     });

--- a/app/javascript/Application/components/Assessment/Assessment.js
+++ b/app/javascript/Application/components/Assessment/Assessment.js
@@ -77,9 +77,7 @@ class Assessment extends Component {
 
   updateCaregiverName = (caregiverIndex, caregiverName) => {
     const assessment = cloneDeep(this.props.assessment);
-    const domains = assessment.state.domains;
-    for (let i = 0; i < domains.length; i++) {
-      const domain = domains[i];
+    for (const domain of assessment.state.domains) {
       if (domain.caregiver_index === caregiverIndex) {
         domain.caregiver_name = caregiverName;
         break;

--- a/app/javascript/Application/components/Assessment/Assessment.test.js
+++ b/app/javascript/Application/components/Assessment/Assessment.test.js
@@ -80,6 +80,28 @@ describe('<Assessment />', () => {
     });
   });
 
+  describe('#updateCaregiverName()', () => {
+    describe('onUpdateAssessment call back', () => {
+      it('is invoked when caregiver name is updated', () => {
+        // given
+        const mockFn = jest.fn();
+        const initialAssessment = cloneDeep(assessment);
+        initialAssessment.state.domains[0] = enhanceDomainToCaregiver(initialAssessment.state.domains[0]);
+        const wrapper = mount(<Assessment onAssessmentUpdate={mockFn} assessment={initialAssessment} i18n={i18n} />);
+        expect(initialAssessment.state.domains[0].caregiver_name).toBeUndefined();
+
+        // when
+        wrapper.instance().updateCaregiverName('a', 'New Name');
+
+        // then
+        const updatedAssessment = cloneDeep(assessment);
+        updatedAssessment.state.domains[0] = enhanceDomainToCaregiver(updatedAssessment.state.domains[0]);
+        updatedAssessment.state.domains[0].caregiver_name = 'New Name';
+        expect(mockFn).toHaveBeenCalledWith(updatedAssessment);
+      });
+    });
+  });
+
   describe('caregiver domain', () => {
     it('adds caregiver domain', () => {
       // given

--- a/app/javascript/Application/components/Assessment/Domain.js
+++ b/app/javascript/Application/components/Assessment/Domain.js
@@ -7,26 +7,28 @@ import Typography from '@material-ui/core/Typography';
 import Tooltip from '@material-ui/core/Tooltip';
 import Divider from '@material-ui/core/Divider';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import { Input } from 'reactstrap';
 import { Item } from './';
 import { getI18nByCode } from './I18nHelper';
 import { isA11yAllowedInput } from '../../util/events';
 
 import './style.sass';
 
-const initI18nValue = i18n => ({
-  title: (i18n['_title_'] || '').toUpperCase(),
-  description: i18n['_description_'] || 'No Description',
+const mapPropsToState = props => ({
+  title: (props.i18n['_title_'] || '').toUpperCase(),
+  description: props.i18n['_description_'] || 'No Description',
+  caregiverName: props.domain.caregiver_name,
 });
 
 /* eslint-disable camelcase */
 class Domain extends Component {
   constructor(props) {
     super(props);
-    this.state = initI18nValue(props.i18n);
+    this.state = mapPropsToState(props);
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
-    this.setState(initI18nValue(nextProps.i18n));
+    this.setState(mapPropsToState(nextProps));
   }
 
   renderItems = items => {
@@ -72,6 +74,30 @@ class Domain extends Component {
     }
   };
 
+  handleInternalCaregiverNameUpdate = event => {
+    this.setState({ caregiverName: event.target.value });
+  };
+
+  handleCaregiverNameUpdate = () => {
+    this.props.onCaregiverNameUpdate(this.props.domain.caregiver_index, this.state.caregiverName);
+  };
+
+  renderCaregiverName = () => {
+    return (
+      <div className={'caregiver-name-wrapper'}>
+        <Input
+          bsSize="lg"
+          placeholder="Caregiver Name"
+          className={'caregiver-name'}
+          value={this.state.caregiverName}
+          maxLength={50}
+          onChange={this.handleInternalCaregiverNameUpdate}
+          onBlur={this.handleCaregiverNameUpdate}
+        />
+      </div>
+    );
+  };
+
   renderCaregiverDomainControls() {
     return (
       <div className={'caregiver-domain-controls'}>
@@ -107,8 +133,8 @@ class Domain extends Component {
 
   render = () => {
     const { assessmentUnderSix } = this.props;
-    const { items, under_six, above_six, is_caregiver_domain, caregiver_index } = this.props.domain;
-    const { title, description } = this.state;
+    const { items, under_six, above_six, is_caregiver_domain } = this.props.domain;
+    const { title, description, caregiverName } = this.state;
     return (assessmentUnderSix && under_six) || (!assessmentUnderSix && above_six) ? (
       <ExpansionPanel style={{ backgroundColor: '#114161' }}>
         <ExpansionPanelSummary
@@ -116,7 +142,7 @@ class Domain extends Component {
           style={{ minHeight: '28px' }}
         >
           <Typography variant="title" style={{ color: 'white' }}>
-            {title} {caregiver_index && `- ${caregiver_index.toUpperCase()}`}
+            {title} {caregiverName && `- ${caregiverName}`}
           </Typography>
           {description ? (
             <Tooltip title={description} placement="top-end" classes={{ popper: 'domain-tooltip' }}>
@@ -125,6 +151,7 @@ class Domain extends Component {
           ) : null}
         </ExpansionPanelSummary>
         <ExpansionPanelDetails style={{ display: 'block', padding: '0', backgroundColor: 'white' }}>
+          {is_caregiver_domain && this.renderCaregiverName()}
           {this.renderItems(items)}
           {is_caregiver_domain && this.renderCaregiverDomainControls()}
         </ExpansionPanelDetails>
@@ -144,6 +171,7 @@ Domain.propTypes = {
   onConfidentialityUpdate: PropTypes.func.isRequired,
   onAddCaregiverDomain: PropTypes.func.isRequired,
   onRemoveCaregiverDomain: PropTypes.func.isRequired,
+  onCaregiverNameUpdate: PropTypes.func.isRequired,
 };
 
 Domain.defaultProps = {

--- a/app/javascript/Application/components/Assessment/Domain.js
+++ b/app/javascript/Application/components/Assessment/Domain.js
@@ -76,26 +76,30 @@ class Domain extends Component {
     return (
       <div className={'caregiver-domain-controls'}>
         <h5>
-          <div
-            onClick={this.handleRemoveCaregiverDomain}
-            onKeyPress={this.handleRemoveCaregiverDomain}
-            className={'caregiver-control'}
-            role={'button'}
-            tabIndex={0}
-          >
-            - REMOVE CAREGIVER
-          </div>
-        </h5>
-        <h5>
-          <div
-            onClick={this.handleAddCaregiverDomain}
-            onKeyPress={this.handleAddCaregiverDomain}
-            className={'caregiver-control'}
-            role={'button'}
-            tabIndex={0}
-          >
-            + ADD CAREGIVER
-          </div>
+          <ul className={'caregiver-domain-controls-list'}>
+            <li>
+              <div
+                onClick={this.handleRemoveCaregiverDomain}
+                onKeyPress={this.handleRemoveCaregiverDomain}
+                className={'caregiver-control'}
+                role={'button'}
+                tabIndex={0}
+              >
+                - REMOVE CAREGIVER
+              </div>
+            </li>
+            <li>
+              <div
+                onClick={this.handleAddCaregiverDomain}
+                onKeyPress={this.handleAddCaregiverDomain}
+                className={'caregiver-control'}
+                role={'button'}
+                tabIndex={0}
+              >
+                + ADD CAREGIVER
+              </div>
+            </li>
+          </ul>
         </h5>
       </div>
     );

--- a/app/javascript/Application/components/Assessment/Domain.test.js
+++ b/app/javascript/Application/components/Assessment/Domain.test.js
@@ -37,6 +37,7 @@ const domainComponentDefault = (
     onConfidentialityUpdate={() => {}}
     onAddCaregiverDomain={() => {}}
     onRemoveCaregiverDomain={() => {}}
+    onCaregiverNameUpdate={() => {}}
   />
 );
 
@@ -63,11 +64,12 @@ describe('<Domain />', () => {
           onConfidentialityUpdate={() => {}}
           onAddCaregiverDomain={() => {}}
           onRemoveCaregiverDomain={() => {}}
+          onCaregiverNameUpdate={() => {}}
         />
       );
       const wrapper = mount(domainComponent);
       const foldedText = wrapper.text();
-      expect(foldedText).toMatch(/TITLE - A/);
+      expect(foldedText).toMatch(/TITLE/);
       expect(foldedText).toMatch(/- REMOVE CAREGIVER/);
       expect(foldedText).toMatch(/\+ ADD CAREGIVER/);
     });
@@ -90,6 +92,7 @@ describe('<Domain />', () => {
           onConfidentialityUpdate={() => {}}
           onAddCaregiverDomain={callbackMock}
           onRemoveCaregiverDomain={() => {}}
+          onCaregiverNameUpdate={() => {}}
         />
       );
       const wrapper = mount(domainComponent);
@@ -118,6 +121,7 @@ describe('<Domain />', () => {
           onConfidentialityUpdate={() => {}}
           onAddCaregiverDomain={() => {}}
           onRemoveCaregiverDomain={callbackMock}
+          onCaregiverNameUpdate={() => {}}
         />
       );
       const wrapper = mount(domainComponent);
@@ -126,6 +130,83 @@ describe('<Domain />', () => {
       removeCaregiverButton.simulate('keypress', { key: 'Enter' });
       removeCaregiverButton.simulate('keypress', { key: 'Space' });
       expect(callbackMock.mock.calls.length).toBe(2);
+    });
+
+    describe('caregiver name', () => {
+      describe('#handleCaregiverNameUpdate()', () => {
+        describe('when caregiver name is changed', () => {
+          it('updates domain header with the updated name', () => {
+            // given
+            const domain = {
+              ...domainDefault,
+              is_caregiver_domain: true,
+              caregiver_index: 'a',
+              caregiver_name: undefined,
+            };
+            const domainComponent = (
+              <Domain
+                key={'1'}
+                domain={{ ...domain }}
+                assessmentUnderSix={true}
+                i18n={{ ...i18nDefault }}
+                i18nAll={{}}
+                onRatingUpdate={() => {}}
+                onConfidentialityUpdate={() => {}}
+                onAddCaregiverDomain={() => {}}
+                onRemoveCaregiverDomain={() => {}}
+                onCaregiverNameUpdate={() => {}}
+              />
+            );
+            const wrapper = mount(domainComponent);
+            const nameInput = wrapper.find('.caregiver-name').at(0);
+
+            // when
+            nameInput.simulate('change', { target: { value: 'Full Name' } });
+
+            // then
+            expect(wrapper.state('caregiverName')).toEqual('Full Name');
+            expect(wrapper.find('ExpansionPanelSummary').text()).toMatch(/Full Name/);
+          });
+        });
+
+        describe('when caregiver name input blurs', () => {
+          it('invokes onCaregiverNameUpdate() callback', () => {
+            // given
+            const domain = {
+              ...domainDefault,
+              is_caregiver_domain: true,
+              caregiver_index: 'a',
+              caregiver_name: undefined,
+            };
+            const callbackMock = jest.fn();
+            const domainComponent = (
+              <Domain
+                key={'1'}
+                domain={{ ...domain }}
+                assessmentUnderSix={true}
+                i18n={{ ...i18nDefault }}
+                i18nAll={{}}
+                onRatingUpdate={() => {}}
+                onConfidentialityUpdate={() => {}}
+                onAddCaregiverDomain={() => {}}
+                onRemoveCaregiverDomain={() => {}}
+                onCaregiverNameUpdate={callbackMock}
+              />
+            );
+            const wrapper = mount(domainComponent);
+            const nameInput = wrapper.find('.caregiver-name').at(0);
+            nameInput.simulate('change', { target: { value: 'Full Name' } });
+
+            // when
+            nameInput.simulate('blur');
+
+            // then
+            expect(callbackMock.mock.calls.length).toBe(1);
+            expect(callbackMock.mock.calls[0][0]).toBe('a');
+            expect(callbackMock.mock.calls[0][1]).toBe('Full Name');
+          });
+        });
+      });
     });
   });
 });

--- a/app/javascript/Application/components/Assessment/style.sass
+++ b/app/javascript/Application/components/Assessment/style.sass
@@ -54,6 +54,14 @@
   cursor: pointer
   font-weight: bold
 
+.caregiver-name-wrapper
+  padding: 0.4rem
+
+.caregiver-name
+  margin-bottom: 0.7rem
+  margin-left: 0.2rem
+  width: 40%
+
 //********************
 //Item
 //********************

--- a/app/javascript/Application/components/Assessment/style.sass
+++ b/app/javascript/Application/components/Assessment/style.sass
@@ -40,14 +40,18 @@
   margin: .1rem 0 0 .7rem
 
 .caregiver-domain-controls
-  display: grid
-  width: 100%
+  display: flex
+  justify-content: flex-end
+
+.caregiver-domain-controls-list
+  list-style-type: none
+  text-align: right
+  width: fit-content
   padding: 1.5rem
 
 .caregiver-control
   color: $aspen
   cursor: pointer
-  float: right
   font-weight: bold
 
 //********************


### PR DESCRIPTION
## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
The main idea is that caregiver name is stored in the state of Domain component when the user enters the name to make it possible to update the name in the Domain's header. When the input field is blurred the caregiver name is stored in the full assessment state in the Assessment component's state.

## Tests
<!--- Please indicate applicable tests -->
- [x] I used TDD to develop the feature
- [x] I have included unit tests
- [ ] I have included new acceptance tests or modified existing ones
- [ ] I have included other tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I ran all my tests locally which were green.
- [x] My code adds no new issues to Code Climate
- [x] I ran all the linters for the project.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build (or bring donuts if I leave things broken), to check linters, use best practices, to leave the code in better shape than I found it, and to have a good day.
