### PR TITLE
CANS-860. IE Browser - Page does not get back to the top after all the save messages disappear

### DIFF
--- a/app/javascript/Application/components/common/GlobalAlert.js
+++ b/app/javascript/Application/components/common/GlobalAlert.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { Container, Row, Col } from 'reactstrap'
 import { CloseableAlert } from './CloseableAlert'
 import { globalAlertService } from '../../util/GlobalAlertService'
+import { isIE } from '../../util/common'
 
 let nextKey = 0
 
@@ -12,6 +13,13 @@ export class GlobalAlert extends Component {
       alerts: [],
     }
     globalAlertService.subscribe(this.onAlertEvent)
+  }
+
+  componentDidUpdate() {
+    if (isIE) {
+      // This is a bug fix for IE when alert is closed, but the empty space is still reserved for it
+      window.Stickyfill.rebuild()
+    }
   }
 
   onAlertEvent = ({ message, type, isAutoCloseable }) => {

--- a/app/javascript/Application/util/common.js
+++ b/app/javascript/Application/util/common.js
@@ -38,3 +38,7 @@ export const isSafari =
   (!window.safari || (typeof safari !== 'undefined' && safari.pushNotification)).toString() ===
     '[object SafariRemoteNotification]'
 /* eslint-enable no-undef */
+
+/* eslint-disable spaced-comment */
+export const isIE = /*@cc_on!@*/ false || Boolean(document.documentMode)
+/* eslint-enable spaced-comment */


### PR DESCRIPTION
## JIRA
https://osi-cwds.atlassian.net/browse/CANS-860

## Description
This is a bug fix for IE when an alert from the Global Alert component is closed, but the empty space is still reserved for it. 
The root cause for it is a possible IE bug in "stickyfill" library that we use for making components sticky. For some reason in IE stickyfill was not recalculating a height of the element in some cases so I am doing it manually on componentDidUpdate lifecycle method.

## Tests
<!--- Please indicate applicable tests -->
- [ ] I used TDD to develop the feature
- [ ] I have included unit tests
- [ ] I have included new acceptance tests or modified existing ones
- [ ] I have included other tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I ran all my tests locally which were green.
- [ ] My code adds no new issues to Code Climate
- [x] I ran all the linters for the project.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build (or bring donuts if I leave things broken), to check linters, use best practices, to leave the code in better shape than I found it, and to have a good day.
