### PR TITLE
Missing test case scenarios.

### DIFF
--- a/spec/acceptance_helpers/resource_helper.rb
+++ b/spec/acceptance_helpers/resource_helper.rb
@@ -348,15 +348,38 @@ module ResourceHelper
   def verify_radio_buttons_on_assessment_header
     find('#add-new-cans').click
     expect(page).to have_content 'CANS Communimetric Assessment Form'
-    find('#age-0-5-button', wait: 15).click
-    find('#has-caregiver-yes').click
-    find('#can-release-control').click
+    find('#age-0-5-button').click
+    find('#age-0-5-button').click
     substance_use_disorder_text = [
       'By selecting NO, Items 7, 48, and EC 41',
       '(Substance Use Disorder Items) from this CANS assessment',
       'will be redacted when printed.'
     ].join(' ')
+    current_date = Time.now.strftime('%m/%d/%Y')
+    expect(find('#assessment-date_input').value).to eq(current_date)
+    expect(page).to have_content('Assessment Conducted by', wait: 10)
+    expect(page).to have_css '.assessment-form-header-case-or-referral-number'
     expect(page).to have_content(substance_use_disorder_text, wait: 45)
+    expect(page).to have_css '.warning-text'
+    expect(page).to have_content('Age Range 0-5', wait: 10)
+    expect(page).to have_content('Caregiver Resources And Needs Domain', wait: 45)
+    find('#domain11-expand').click
+    expect(find('#input-can-release-no', visible: false).checked?).to be(true)
+    expect(find('#input-has-caregiver-yes', visible: false).checked?).to be(true)
+    expect(find('#SUBSTANCE_USE_CAREGIVERCheckbox')\
+      .find('input', visible: false).checked?).to be(true)
+  end
+
+  def validate_domain_radio_and_chevron
+    find('#domain5-expand').click
+    find('#IMPULSIVITY_HYPERACTIVITY-item-expand').click
+    find('#input-IMPULSIVITY_HYPERACTIVITY-0-select').click
+    expect(page).to have_content('Item Description', wait: 10)
+    find('#IMPULSIVITY_HYPERACTIVITY-item-expand').click
+    expect(page).not_to have_content('Item Description', wait: 10)
+    progress_bar_value = page.all('span.progress-value', match: :first).map(&:text)
+    progress_bar_value.each { |element| @total_radio_selected.push(element) }
+    expect(progress_bar_value).to eq(@total_radio_selected)
   end
 
   def save_assessment_form_age_0_5(client_identifier)

--- a/spec/regression/case_worker_scenarios_spec.rb
+++ b/spec/regression/case_worker_scenarios_spec.rb
@@ -6,6 +6,7 @@ require 'feature'
 feature 'Case Worker Functionality' do
   before(:all) do
     @domain_total_count = []
+    @total_radio_selected = []
   end
 
   after(:all) do
@@ -27,11 +28,14 @@ feature 'Case Worker Functionality' do
     visit_client_profile(CLIENT_NAME)
     expect(page).to have_content('ADD CANS')
     verify_radio_buttons_on_assessment_header
-    fetch_challenges_domain
+    validate_domain_radio_and_chevron
     click_button 'Save'
     visit_client_profile(CLIENT_NAME)
     visit_client_profile(CLIENT_NAME)
     expect(page).to have_content('In Progress')
+    current_date = Time.now.strftime('%m/%d/%Y')
+    find(:link, current_date + ' CANS', match: :first).click
+    expect(page).to have_content 'CANS Communimetric Assessment Form'
   end
 
   def fill_out_form_then_check_domain_total


### PR DESCRIPTION
https://osi-cwds.atlassian.net/browse/CANS-915

## Description
Scenario 17: missing outcome verification 
Upon clicking "ADD CANS" the user is routed to the CANS communimetric assessment page and a card is displayed that includes the following: 
(1) Assessment Date defaults to the current date; - Done
(3) Assessment Conducted by - Done, expecting label as confirmed by [~Stan.Hailen]
(4) Referral Number (or Case Number) (or Referral/Case Number) - Done, expecting label as confirmed
(6) Authorization for release of information on file? with a default to "No" and the message related to redaction. - Done

Scenario 20: missing outcome verification
The appropriate age selected is highlighted and the matching assessment appears below the card 
- This test is already covered inside *case_worker_scenarios_spec.rb* line number 46

Scenario 24: missing test steps and outcome verification
Verify the "Child/Youth has caregiver?" selection is defaulted to "Yes"	
The Caregiver Resources and Needs Domain is displayed in the assessment tool 
- Done.

Scenario 32: not all validations are implemented
Verify the "Authorization for Release of Info on file?" selection is defaulted to "No"	
A redaction message reading "By selecting NO, Items 7, 48, and EC 41 (Substance Abuse Disorder Items) from this CANS assessment will be redacted when printed)" is displayed in red font and appropriate items are marked as confidential
- Done.

Scenarios 34 and 35 are not implemented 
Click on the chevron icon (looks like ˅) to the right of any domain	
The corresponding domain is expanded and the items within the domain are displayed below the domain header 
Click on the chevron icon again. The corresponding domain collapses
- Done (domain total is already covered I have added test to verify progress bar value.

Scenario 47: missing outcome verification
A message reading ""Successful CANS Assessment has been saved. Click here to return to Child/Youth Profile"" will display at the top of the page for 8 seconds when the save button is clicked. - no validation implemented
- Done (please note we are only validating if the message appear after the save is clicked) as discussed [~Stan.Hailen]

Scenario 49: not implemented step
Locate the CANS Assessment (with date matching your test assessment) that has an "In Progress" status and click on the link (for example 12/17/2018 CANS).	
User is routed back to the ""In Progress"" assessment previously worked on.
- Done

**Testing**
In order to test this script please use the user id and password shared earlier and update the file - **run-regression-test.sh** and update "test:regression" in package.json to point to index page inside regression folder.

## Tests
<!--- Please indicate applicable tests -->
- [ ] I used TDD to develop the feature
- [ ] I have included unit tests
- [x] I have included new acceptance tests or modified existing ones
- [ ] I have included other tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I ran all my tests locally which were green.
- [x] My code adds no new issues to Code Climate
- [x] I ran all the linters for the project.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build (or bring donuts if I leave things broken), to check linters, use best practices, to leave the code in better shape than I found it, and to have a good day.
