### PR TITLE
Loosen restrictions on references

### DIFF
--- a/app/javascript/Application/components/Assessment/AssessmentMutations.js
+++ b/app/javascript/Application/components/Assessment/AssessmentMutations.js
@@ -2,38 +2,30 @@ const INDICES = 'abcdefghijklmnopqrstuvwxyz'
 
 export const updateCaregiverDomainsIndices = domains => {
   const result = domains.reduce(
-    ({ newDomains, numChanged, nextCaregiverIndex }, domain) => {
+    ({ newDomains, nextCaregiverIndex }, domain) => {
       let newDomain
-      let newNumChanged
       let newNextCaregiverIndex
 
       const nextCaregiverChar = INDICES.charAt(nextCaregiverIndex)
 
       if (domain.is_caregiver_domain === false) {
         newDomain = domain
-        newNumChanged = numChanged
         newNextCaregiverIndex = nextCaregiverIndex
-      } else if (domain.caregiver_index === nextCaregiverChar) {
-        newDomain = domain
-        newNumChanged = numChanged
-        newNextCaregiverIndex = nextCaregiverIndex + 1
       } else {
         newDomain = {
           ...domain,
           caregiver_index: nextCaregiverChar,
         }
-        newNumChanged = numChanged + 1
         newNextCaregiverIndex = nextCaregiverIndex + 1
       }
 
       newDomains.push(newDomain)
-      return { newDomains, numChanged: newNumChanged, nextCaregiverIndex: newNextCaregiverIndex }
+      return { newDomains, nextCaregiverIndex: newNextCaregiverIndex }
     },
-    { newDomains: [], numChanged: 0, nextCaregiverIndex: 0 }
+    { newDomains: [], nextCaregiverIndex: 0 }
   )
 
-  const { newDomains, numChanged } = result
-  return numChanged > 0 ? newDomains : domains
+  return result.newDomains
 }
 
 const updateIfChanged = (obj, key, value) => {
@@ -43,42 +35,23 @@ const updateIfChanged = (obj, key, value) => {
   return { ...obj, [key]: value }
 }
 
-const mapIfChanged = (array, updater) => {
-  const result = array.reduce(
-    ({ newArray, isChanged }, item) => {
-      const newItem = updater(item)
-      newArray.push(newItem)
-      return { newArray, isChanged: isChanged || newItem !== item }
-    },
-    { newArray: [], isChanged: false }
-  )
-
-  const { newArray, isChanged } = result
-  return isChanged ? newArray : array
-}
-
-const setDomains = (assessment, newDomains) => {
-  return newDomains !== assessment.state.domains
-    ? { ...assessment, state: { ...assessment.state, domains: newDomains } }
-    : assessment
-}
-
-const setItems = (domain, newItems) => {
-  return newItems !== domain.items ? { ...domain, items: newItems } : domain
-}
-
-export const updateItem = (assessment, itemCode, key, value, itemCaregiverIndex) => {
-  return setDomains(
-    assessment,
-    mapIfChanged(assessment.state.domains, domain => {
+export const updateItem = (assessment, itemCode, key, value, itemCaregiverIndex) => ({
+  ...assessment,
+  state: {
+    ...assessment.state,
+    domains: assessment.state.domains.map(domain => {
       if (itemCaregiverIndex !== domain.caregiver_index) {
         return domain
       }
-
-      return setItems(
-        domain,
-        mapIfChanged(domain.items, item => (item.code === itemCode ? updateIfChanged(item, key, value) : item))
-      )
-    })
-  )
-}
+      return {
+        ...domain,
+        items: domain.items.map(item => {
+          if (item.code !== itemCode) {
+            return item
+          }
+          return updateIfChanged(item, key, value)
+        }),
+      }
+    }),
+  },
+})

--- a/app/javascript/Application/components/Assessment/AssessmentMutations.test.js
+++ b/app/javascript/Application/components/Assessment/AssessmentMutations.test.js
@@ -50,18 +50,6 @@ describe('AssessmentMutations', () => {
       expect(newDomains[2]).toBe(nonCaregiver)
     })
 
-    it('leaves untouched any caregiver domains that were in the right order', () => {
-      const domains = [caregiverC, caregiverB, caregiverA, nonCaregiver]
-      const newDomains = updateCaregiverDomainsIndices(domains)
-      expect(newDomains[1]).toBe(caregiverB)
-    })
-
-    it('leaves the entire array untouched if nothing changes', () => {
-      const domains = [caregiverA, caregiverB, caregiverC, nonCaregiver]
-      const newDomains = updateCaregiverDomainsIndices(domains)
-      expect(newDomains).toBe(domains)
-    })
-
     it('does not update domains in place', () => {
       const aJSON = JSON.stringify(caregiverA)
       const domains = [caregiverB, caregiverA, nonCaregiver]
@@ -97,10 +85,6 @@ describe('AssessmentMutations', () => {
         expect(updated.state.domains[1].items[0]).toBe(initial.state.domains[1].items[0])
       })
 
-      it('preserves references to untouched domains', () => {
-        expect(updated.state.domains[1]).toBe(initial.state.domains[1])
-      })
-
       it('preserves references to untouched assessment properties', () => {
         expect(updated.other).toBe(initial.other)
       })
@@ -111,16 +95,35 @@ describe('AssessmentMutations', () => {
       })
     })
 
-    it('returns the same assessment when the property is already set', () => {
-      const initialDomains = [
-        { id: 1, items: [{ code: 'A' }, { code: 'B', myKey: 'myValue' }] },
-        { id: 2, items: [{ code: 'C' }] },
-      ]
-      const initial = { other: { foo: 'bar' }, state: { domains: initialDomains } }
+    describe('when the property is already set', () => {
+      beforeEach(() => {
+        initialDomains = [
+          { id: 1, items: [{ code: 'A' }, { code: 'B', myKey: 'myValue' }] },
+          { id: 2, items: [{ code: 'C' }] },
+        ]
+        initial = { other: { foo: 'bar' }, state: { domains: initialDomains } }
+        initialJSON = JSON.stringify(initial)
 
-      const updated = updateItem(initial, 'B', 'myKey', 'myValue')
+        updated = updateItem(initial, 'B', 'myKey', 'myValue')
+      })
 
-      expect(updated).toBe(initial)
+      it('still has the property', () => {
+        expect(updated.state.domains[0].items[1][key]).toBe(value)
+      })
+
+      it('preserves references to all (untouched) items', () => {
+        expect(updated.state.domains[0].items[0]).toBe(initial.state.domains[0].items[0])
+        expect(updated.state.domains[0].items[1]).toBe(initial.state.domains[0].items[1])
+        expect(updated.state.domains[1].items[0]).toBe(initial.state.domains[1].items[0])
+      })
+
+      it('preserves references to untouched assessment properties', () => {
+        expect(updated.other).toBe(initial.other)
+      })
+
+      it('does not mutate the original object', () => {
+        expect(JSON.stringify(initial)).toBe(initialJSON)
+      })
     })
 
     describe('when updating a caregiver item', () => {
@@ -160,11 +163,6 @@ describe('AssessmentMutations', () => {
       it('preserves references to untouched items', () => {
         expect(updated.state.domains[0].items[0]).toBe(initial.state.domains[0].items[0])
         expect(updated.state.domains[1].items[0]).toBe(initial.state.domains[1].items[0])
-      })
-
-      it('preserves references to untouched domains', () => {
-        expect(updated.state.domains[0]).toBe(initial.state.domains[0])
-        expect(updated.state.domains[2]).toBe(initial.state.domains[2])
       })
 
       it('preserves references to untouched assessment properties', () => {


### PR DESCRIPTION
## JIRA

No story. Leaving this as a Draft at the moment, for discussion.

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->

This is based on some feedback from recent PRs, to try to simplify the code in AssessmentMutations. By loosening some of the requirements that references must be the same when no value changed, we can remove some additional checks and state tracking. However, this does have performance implications. Even if every item is the same, the list of items will be different, causing DomainItemList to re-render (for each Domain). This is not as bad as rendering every item, but may still be noticeable.

This PR basically subjects us to the issues that Immutable.js suffers from, where mapping without changing any values still returns a new Immutable object.

## Tests
<!--- Please indicate applicable tests -->
- [x] I used TDD to develop the feature
- [ ] I have included unit tests
- [ ] I have included new acceptance tests or modified existing ones
- [ ] I have included other tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] My code follows the code style of this project.
- [ ] I ran all my tests locally which were green.
- [ ] My code adds no new issues to Code Climate
- [ ] I ran all the linters for the project.
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [ ] I promise on my honor as a CWDS developer to ensure I don't break the build (or bring donuts if I leave things broken), to check linters, use best practices, to leave the code in better shape than I found it, and to have a good day.
