### PR TITLE
Remove assessment from AssessmentOptions props

### DIFF
--- a/app/javascript/Application/components/Assessment/AssessmentFormHeader.js
+++ b/app/javascript/Application/components/Assessment/AssessmentFormHeader.js
@@ -191,7 +191,6 @@ class AssessmentFormHeader extends PureComponent {
           onAssessmentUpdate={this.props.onAssessmentUpdate}
         />
         <AssessmentOptions
-          assessment={assessment}
           canReleaseConfidentialInfo={canReleaseInfo}
           hasCaregiver={hasCaregiver}
           isDisabled={this.props.disabled}

--- a/app/javascript/Application/components/Assessment/AssessmentFormHeader/AssessmentOptions.js
+++ b/app/javascript/Application/components/Assessment/AssessmentFormHeader/AssessmentOptions.js
@@ -6,42 +6,40 @@ import CanReleaseInfoQuestion from './CanReleaseInfoQuestion'
 import ConfidentialityAlert from './ConfidentialityAlert'
 
 const AssessmentOptions = ({
-  assessment,
+  canReleaseConfidentialInfo,
+  hasCaregiver,
   isDisabled,
   isUnderSix,
   onCanReleaseInfoChange,
   onHasCaregiverChange,
   onHasCaregiverNoClicked,
   substanceUseItemsIds,
-}) => {
-  const hasCaregiver = Boolean(assessment.has_caregiver)
-  const canReleaseConfidentialInfo = Boolean(assessment.can_release_confidential_info)
-  return (
-    <Row>
-      <HasCaregiverQuestion
-        hasCaregiver={hasCaregiver}
-        disabled={isDisabled}
-        onHasCaregiverChange={onHasCaregiverChange}
-        onHasCaregiverNoClicked={onHasCaregiverNoClicked}
-      />
-      <CanReleaseInfoQuestion
-        canReleaseConfidentialInfo={canReleaseConfidentialInfo}
-        message={
-          <ConfidentialityAlert
-            canReleaseConfidentialInfo={canReleaseConfidentialInfo}
-            isUnderSix={isUnderSix}
-            substanceUseItemsIds={substanceUseItemsIds}
-          />
-        }
-        isDisabled={isDisabled}
-        onCanReleaseInfoChange={onCanReleaseInfoChange}
-      />
-    </Row>
-  )
-}
+}) => (
+  <Row>
+    <HasCaregiverQuestion
+      hasCaregiver={hasCaregiver}
+      disabled={isDisabled}
+      onHasCaregiverChange={onHasCaregiverChange}
+      onHasCaregiverNoClicked={onHasCaregiverNoClicked}
+    />
+    <CanReleaseInfoQuestion
+      canReleaseConfidentialInfo={canReleaseConfidentialInfo}
+      message={
+        <ConfidentialityAlert
+          canReleaseConfidentialInfo={canReleaseConfidentialInfo}
+          isUnderSix={isUnderSix}
+          substanceUseItemsIds={substanceUseItemsIds}
+        />
+      }
+      isDisabled={isDisabled}
+      onCanReleaseInfoChange={onCanReleaseInfoChange}
+    />
+  </Row>
+)
 
 AssessmentOptions.propTypes = {
-  assessment: PropTypes.object.isRequired,
+  canReleaseConfidentialInfo: PropTypes.bool,
+  hasCaregiver: PropTypes.bool,
   isDisabled: PropTypes.bool,
   isUnderSix: PropTypes.bool,
   onCanReleaseInfoChange: PropTypes.func.isRequired,
@@ -54,6 +52,8 @@ AssessmentOptions.propTypes = {
 }
 
 AssessmentOptions.defaultProps = {
+  canReleaseConfidentialInfo: false,
+  hasCaregiver: false,
   isDisabled: undefined,
   isUnderSix: undefined,
 }

--- a/app/javascript/Application/components/Assessment/AssessmentFormHeader/AssessmentOptions.test.js
+++ b/app/javascript/Application/components/Assessment/AssessmentFormHeader/AssessmentOptions.test.js
@@ -21,7 +21,8 @@ describe('AssessmentOptions', () => {
   } = {}) =>
     shallow(
       <AssessmentOptions
-        assessment={assessment}
+        hasCaregiver={assessment.has_caregiver}
+        canReleaseConfidentialInfo={assessment.can_release_confidential_info}
         isDisabled={isDisabled}
         isUnderSix={isUnderSix}
         onCanReleaseInfoChange={onCanReleaseInfoChange}


### PR DESCRIPTION
Instead, it can depend on the primitive values it needs, which
helps lead to less unnecessary rendering when other unrelated
inputs change the assessment.

This is the first of potentially many similar changes. As the user types into the ConductedBy fields, the assessment is changed. This leads to _a lot_ of re-rendering, which is slow and potentially the cause of Capybara's intermittent issues. We're trying to restructure these components to render much less often.

## Tests
<!--- Please indicate applicable tests -->
- [x] I used TDD to develop the feature
- [x] I have included unit tests
- [ ] I have included new acceptance tests or modified existing ones
- [ ] I have included other tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I ran all my tests locally which were green.
- [x] My code adds no new issues to Code Climate
- [x] I ran all the linters for the project.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build (or bring donuts if I leave things broken), to check linters, use best practices, to leave the code in better shape than I found it, and to have a good day.
